### PR TITLE
Dont resolve absolute paths

### DIFF
--- a/spec/parser_spec.cr
+++ b/spec/parser_spec.cr
@@ -20,7 +20,7 @@ class TestProcessor < Processor
   end
 
   def on_include(parent, child)
-    @includes[parent] << child
+    @includes[parent.to_s] << child.to_s
   end
 
   def on_define(key, val)
@@ -34,10 +34,9 @@ end
 
 describe Parser do
   project_dir = File.expand_path(File.join(__FILE__, "../.."))
-  css_dir = File.join(project_dir, "example/assets/css")
 
   resolver = Resolver.new
-  resolver.add(css_dir)
+  resolver.add(File.join(project_dir, "example/assets/css"))
 
   it "processes a simple file with no directives" do
     processor = TestProcessor.new
@@ -65,11 +64,7 @@ describe Parser do
       "  color: $color;\n",
       "}\n"
     ])
-
-    processor.includes.should eq({
-      File.join(css_dir, "baz.css") => [File.join(css_dir, "qux.css")]
-    })
-
+    processor.includes.should eq({ "baz.css" => ["qux.css"] })
     processor.defines.should eq(Hash(String, String).new)
   end
 
@@ -115,14 +110,10 @@ describe Parser do
     processor.defines.should eq({ "$color" => "\"red\"" })
 
     processor.includes.should eq({
-      File.join(css_dir, "bar.css") => [File.join(css_dir, "baz.css")],
-      File.join(css_dir, "baz.css") => [File.join(css_dir, "qux.css")],
-      File.join(css_dir, "foo.css") => [File.join(css_dir, "baz.css")],
-      File.join(css_dir, "root.css") => [
-        File.join(css_dir, "variables.css"),
-        File.join(css_dir, "foo.css"),
-        File.join(css_dir, "bar.css"),
-      ]
+      "bar.css" => ["baz.css"],
+      "baz.css" => ["qux.css"],
+      "foo.css" => ["baz.css"],
+      "root.css" => ["variables.css", "foo.css", "bar.css"]
     })
   end
 end

--- a/spec/processor/makedepend_spec.cr
+++ b/spec/processor/makedepend_spec.cr
@@ -1,13 +1,14 @@
 require "../spec_helper"
 require "../../src/processor/makedepend"
+require "../../src/path"
 
 describe Processor::MakeDepend do
   it "tracks dependencies through #include macros" do
     processor = Processor::MakeDepend.new
-    processor.on_include("root.css", "foo.css")
-    processor.on_include("foo.css", "bar.css")
-    processor.on_include("root.css", "bar.css")
-    processor.on_include("root.css", "baz.css")
+    processor.on_include(Path.new("root.css"), Path.new("foo.css"))
+    processor.on_include(Path.new("foo.css"), Path.new("bar.css"))
+    processor.on_include(Path.new("root.css"), Path.new("bar.css"))
+    processor.on_include(Path.new("root.css"), Path.new("baz.css"))
 
     processor.to_s.should eq <<-OUTPUT
       root.css: foo.css bar.css baz.css
@@ -21,10 +22,12 @@ describe Processor::MakeDepend do
   end
 
   it "converts paths to be relative from the working directory" do
-    prefix = ->(path : String) { File.join(Dir.current, "css", path) }
+    make_path = ->(path : String) do
+      Path.new(File.join(Dir.current, "css", path), File.join("css", path))
+    end
 
     processor = Processor::MakeDepend.new
-    processor.on_include(prefix.call("root.css"), prefix.call("foo.css"))
+    processor.on_include(make_path.call("root.css"), make_path.call("foo.css"))
 
     processor.to_s.should eq <<-OUTPUT
       css/root.css: css/foo.css

--- a/spec/resolver_spec.cr
+++ b/spec/resolver_spec.cr
@@ -37,4 +37,11 @@ describe Resolver do
       end
     end
   end
+
+  it "doesn't resolve absolute paths outside of the search path" do
+    resolver = Resolver.new
+    expect_raises(Resolver::NotFound) do
+      resolver.resolve("/etc/passwd")
+    end
+  end
 end

--- a/spec/resolver_spec.cr
+++ b/spec/resolver_spec.cr
@@ -1,5 +1,6 @@
 require "./spec_helper"
 require "../src/resolver"
+require "../src/path"
 
 describe Resolver do
   project_dir = File.expand_path(File.join(__FILE__, "../.."))
@@ -11,7 +12,8 @@ describe Resolver do
       resolver.add("example")
       path = resolver.resolve("assets/css/foo.css")
 
-      path.should eq(File.join(project_dir, "example/assets/css/foo.css"))
+      path.absolute.should eq(File.join(project_dir, "example/assets/css/foo.css"))
+      path.to_s.should eq("assets/css/foo.css")
     end
   end
 

--- a/src/parser.cr
+++ b/src/parser.cr
@@ -1,21 +1,24 @@
 require "./resolver"
+require "./path"
 
 class Parser
   def initialize(@resolver : Resolver, @processor : Processor)
-    @visited = Set(String).new
+    @visited = Set(Path).new
+  end
+
+  def process(*paths : String)
+    process(paths.to_a)
   end
 
   def process(paths : Array(String))
-    paths.each { |path| process(path) }
+    paths.each { |path| process(@resolver.resolve(path)) }
   end
 
-  def process(path : String)
-    path = @resolver.resolve(path)
-
-    return "" if @visited.includes?(path)
+  def process(path : Path)
+    return if @visited.includes?(path)
     @visited.add(path)
 
-    File.each_line(path) do |line|
+    File.each_line(path.absolute) do |line|
       case line.strip
       when /^#include\s+/
         file = line.strip.sub(/^#include\s+/, "").gsub(/"/, "").gsub(/'/, "")

--- a/src/path.cr
+++ b/src/path.cr
@@ -1,0 +1,19 @@
+class Path
+  getter :absolute
+  getter :relative
+
+  def initialize(@absolute : String, @relative : String)
+  end
+
+  def initialize(absolute)
+    initialize(absolute, absolute)
+  end
+
+  def ==(other)
+    absolute == other.absolute && relative == other.relative
+  end
+
+  def to_s(io)
+    @relative.to_s(io)
+  end
+end

--- a/src/processor/makedepend.cr
+++ b/src/processor/makedepend.cr
@@ -10,8 +10,8 @@ class Processor::MakeDepend < Processor
   end
 
   def on_include(template_path, included_path)
-    template_path = template_path.sub(@@current_dir, "")
-    included_path = included_path.sub(@@current_dir, "")
+    template_path = template_path.absolute.sub(@@current_dir, "")
+    included_path = included_path.absolute.sub(@@current_dir, "")
     @dependencies[template_path] << included_path
   end
 

--- a/src/resolver.cr
+++ b/src/resolver.cr
@@ -1,3 +1,5 @@
+require "./path"
+
 class Resolver
   class NotFound < Errno
     def initialize(path, search_paths)
@@ -6,11 +8,11 @@ class Resolver
   end
 
   @search_paths = [] of String
-  @cache = Hash(String, String).new
+  @cache = Hash(String, Path).new
 
   getter :search_paths
 
-  def resolve(path)
+  def resolve(path : String)
     @cache[path] ||= find(path)
   end
 
@@ -23,11 +25,11 @@ class Resolver
   end
 
   private def find(path)
-    return path if path.starts_with?('/') && File.file?(path)
+    return Path.new(path) if path.starts_with?('/') && File.file?(path)
 
     search_paths.each do |prefix|
       file_path = File.join(prefix, path)
-      return file_path if File.file?(file_path)
+      return Path.new(file_path, path) if File.file?(file_path)
     end
 
     raise NotFound.new(path, search_paths)

--- a/src/resolver.cr
+++ b/src/resolver.cr
@@ -25,8 +25,6 @@ class Resolver
   end
 
   private def find(path)
-    return Path.new(path) if path.starts_with?('/') && File.file?(path)
-
     search_paths.each do |prefix|
       file_path = File.join(prefix, path)
       return Path.new(file_path, path) if File.file?(file_path)


### PR DESCRIPTION
The Resolver allows getting absolute paths, which helped as a speed shortcut. However, this also means we can pass _arbitrary_ absolute paths, like say, `#include "/etc/passwd"`. Which isn't nice.

A solution is to avoid resolving absolute paths and just make sure we resolve paths inside the defined search paths (you're welcome to add `/` to the search path, but that's on you.)
